### PR TITLE
docs: add back changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# 2.1.0
+- NEXT-40431 - Compatibility with Shopware 6.7.
+- NEXT-40431 - Increased the minimum required Shopware version to 6.6.x or 6.7.x.
+- NEXT-40431 - Implemented staged execution for demo data generation and deletion to avoid foreign key constraint violations.
+
+# 2.0.1
+- NEXT-32194 - Compatibility with Shopware 6.6
+
+# 2.0.0
+- NEXT-25677 - Compatibility with Shopware 6.5
+- NEXT-25677 - Demodata is now deleted on deactivation
+
+# 1.0.9
+- Add pipeline
+- Add dev tooling
+- Fix plugin validation errors
+- Fixed plugin activation by CMS page renaming


### PR DESCRIPTION
The original changelog got deleted with #4 in favor of auto generated ones via commit messages which got deleted with #12 :sweat_smile: (because of "old" commit style). The release workflow relies on one of both...