### PR TITLE
ci: verify extension against lowest dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+    reviewers:
+      - 'shopware/product-cc-after-sales'
+    commit-message:
+      prefix: 'chore'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,6 +31,25 @@ jobs:
     with:
       extension_name: ${{ github.event.repository.name }}
 
+  extension_verifier:
+    name: Extension Verifier (lowest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SwagPlatformDemoData
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Remove PHPStan config
+        run: rm phpstan.neon.dist
+
+      - name: Allow composer to resolve advisory-affected releases
+        run: composer config policy.advisories.block false
+
+      - name: Run verifier
+        uses: shopware/github-actions/extension-verifier@main
+        with:
+          action: check
+          check-against: lowest
+
   phpunit:
     name: PHPUnit
     strategy:

--- a/.shopware-extension.yml
+++ b/.shopware-extension.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://shopware.github.io/shopware-cli/shopware-extension-schema.json
+compatibility_date: '2026-08-19'
+
+validation:
+  ignore:
+    # 6.6.0 does not know the 'fundamentals@after-sales' package label
+    - message: 'Parameter #1 $package of attribute class Shopware\Core\Framework\Log\Package constructor expects'


### PR DESCRIPTION
follow-up to shopware/SwagMigrationAssistant#218

- the new `Extension Verifier (lowest)` job uses `shopware-cli` via [`shopware/github-actions/extension-verifier`](https://github.com/shopware/github-actions/tree/main/extension-verifier) to [validate](https://developer.shopware.com/docs/products/tools/cli/validation.html) the plugin against its lowest resolvable dependencies to catch future compat issues in CI
- the pre-existing `#[Package('fundamentals@after-sales')]` findings ignored in `.shopware-extension.yml`, 6.6.0 does not know that package label yet
- dependabot added for github-actions

example output from the [first run of the job](https://github.com/shopware/SwagPlatformDemoData/actions/runs/32269425259/job/96121930178?pr=24):

```text
src/SwagPlatformDemoData.php
  17  error    [phpstan/argument.type]  Parameter #1 $package of attribute class Shopware\Core\Framework\Log\Package constructor expects 'administration'|'business-ops'|'buyers-experience'|'checkout'|'content'|'core'|'customer-order'|'data-services'|'innovation'|'inventory'|'merchant-services'|'sales-channel'|'services-settings'|'storefront'|'stranger-codes'|'system-settings', 'fundamentals@after…' given.

✖ 14 problems (14 errors, 0 warnings)
```