### PR TITLE
ci: remove unsupported dependabot cooldown options

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 14
-      semver-patch-days: 7
     reviewers:
       - 'shopware/product-cc-after-sales'
     commit-message:


### PR DESCRIPTION
https://github.com/shopware/SwagPlatformDemoData/runs/96388884564:

```
The property '#/updates/0/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/0/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

<sup>https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown</sub>