### PR TITLE
ci: run php checks on every pull request

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,11 +2,6 @@ name: PHP checks
 
 on:
   pull_request:
-    paths:
-      - composer.json
-      - src/**/*.php
-      - tests/**/*.php
-      - .github/workflows/**
   push:
     branches:
       - trunk


### PR DESCRIPTION
CI currently can't pass on PRs that only touch other files, see #25:

<img width="793" height="249" alt="image" src="https://github.com/user-attachments/assets/b8552847-f12b-4de2-a3e9-09c6129a8180" />
